### PR TITLE
fix QoS Bus

### DIFF
--- a/home_gateway_multi_table/flowstatistic_monitor.py
+++ b/home_gateway_multi_table/flowstatistic_monitor.py
@@ -104,6 +104,8 @@ class flowstatistic_monitor(app_manager.RyuApp):
                         flow_value.byte_count_1 = flow_value.byte_count_2
                         flow_value.byte_count_2 = stat.byte_count
                         flow_value.rate_calculation()
+                        if flow_value.limited > 0:
+                            flow_value.limited -= 1
 
                 elif stat.match.get('ip_proto') == inet.IPPROTO_UDP:
                     key_tuples += str(stat.match.get('udp_src'))\
@@ -125,6 +127,8 @@ class flowstatistic_monitor(app_manager.RyuApp):
                         flow_value.byte_count_1 = flow_value.byte_count_2
                         flow_value.byte_count_2 = stat.byte_count
                         flow_value.rate_calculation()
+                        if flow_value.limited > 0:
+                            flow_value.limited -= 1
 
     @set_ev_cls(ofp_event.EventOFPPacketIn, MAIN_DISPATCHER)
     def _packet_in_handler(self, ev):

--- a/home_gateway_multi_table/models/flow.py
+++ b/home_gateway_multi_table/models/flow.py
@@ -26,3 +26,9 @@ class Flow:
         """calculate flow rate."""
         if self.byte_count_2 > self.byte_count_1:
             self.rate = (float(self.byte_count_2) - float(self.byte_count_1))/2
+            self.count = 0
+        else:
+            self.counter += 1
+            if self.counter >= 3:
+                self.rate = 0
+                self.counter = 0

--- a/home_gateway_multi_table/qos.py
+++ b/home_gateway_multi_table/qos.py
@@ -55,53 +55,49 @@ class QosControl(app_manager.RyuApp):
 
     def rate_limit_for_member(self, mac, bandwidth):
         meter_id = 0
-        for myid, mybandwidth in qos_config.meter.iteritems():
-            if mybandwidth == bandwidth:
-                meter_id = myid
-        if meter_id == 0 and bandwidth != 'unlimit':
+        if bandwidth != 'unlimit':
             meter_id = self.get_free_meterid()
             self.add_meter(int(bandwidth), meter_id)
         forwarding_config.member_list.get(mac).meter_id = meter_id
-        datapath = forwarding_config.member_list.get(mac).datapath
-        out_port = forwarding_config.member_list.get(mac).port
+        datapath = self.MyDATAPATH
         parser = datapath.ofproto_parser
-        actions = [parser.OFPActionOutput(out_port)]
         match = parser.OFPMatch(eth_dst=mac)
         ofp_helper.add_flow_rate_limit(datapath=datapath,
                                        table_id=self.table_id,
                                        priority=self.member_limit_priority,
                                        match=match,
                                        meter_id=int(meter_id),
-                                       idle_timeout=10)
+                                       idle_timeout=100)
 
     def rate_limit_for_app(self, app, mac, bandwidth):
-        if qos_config.app_list.get(app) is None:
-            new_meter_id = self.get_free_meterid()
-            self.add_meter(bandwidth,new_meter_id)
-            rate_for_member = {mac: {"meter_id" : new_meter_id,"bandwidth" : bandwidth} }
-            qos_config.app_list.update({app : rate_for_member})
-        else:
-            if qos_config.app_list.get(app).get(mac) is None:
+        new_meter_id = 0
+        if(bandwidth != 'unlimit'):
+            # Give this app a new meter
+            if qos_config.app_list.get(app) is None:
                 new_meter_id = self.get_free_meterid()
-                self.add_meter(bandwidth,new_meter_id)
-                qos_config.app_list.get(app).update({mac: {"meter_id" : new_meter_id,"bandwidth" : bandwidth}})
+                self.add_meter(int(bandwidth), new_meter_id)
+                rate_for_member = {mac: {"meter_id": new_meter_id, "bandwidth": bandwidth}}
+                qos_config.app_list.update({app: rate_for_member})
             else:
-                rate_for_member = {mac: {"bandwidth" : bandwidth} }
-                qos_config.app_list.get(app).get(mac)['bandwidth'] = bandwidth
+                if qos_config.app_list.get(app).get(mac) is None:
+                    new_meter_id = self.get_free_meterid()
+                    self.add_meter(int(bandwidth), new_meter_id)
+                    qos_config.app_list.get(app).update({mac: {"meter_id": new_meter_id,"bandwidth" : bandwidth}})
+                else:
+                    rate_for_member = {mac: {"bandwidth": bandwidth} }
+                    qos_config.app_list.get(app).get(mac)['bandwidth'] = bandwidth
 
         # Add rule for all flow which app is this app
-        app_setting = qos_config.app_list.get(app).get(mac)
-        meter_id = app_setting.get('meter_id')
-        bandwidth = app_setting.get('bandwidth')
         datapath = self.MyDATAPATH
         parser = datapath.ofproto_parser
         if mac is not 'all':
             target_host = forwarding_config.member_list.get(mac)
         for key,flow in forwarding_config.flow_list.iteritems():
+            if flow.app != app:
+                continue
             if (mac == 'all') or (target_host.mac == flow.dst_mac) or (target_host.ip == flow.dst_ip):
                 if flow.ip_proto == inet.IPPROTO_TCP:
-                     match = parser.OFPMatch(eth_src=flow.src_mac,
-                                    eth_dst=flow.dst_mac,
+                     match = parser.OFPMatch(
                                     eth_type=ether.ETH_TYPE_IP,
                                     ipv4_src=flow.src_ip,
                                     ipv4_dst=flow.dst_ip,
@@ -109,8 +105,7 @@ class QosControl(app_manager.RyuApp):
                                     tcp_src=flow.src_port,
                                     tcp_dst=flow.dst_port)
                 else:
-                     match = parser.OFPMatch(eth_src=flow.src_mac,
-                                    eth_dst=flow.dst_mac,
+                     match = parser.OFPMatch(
                                     eth_type=ether.ETH_TYPE_IP,
                                     ipv4_src=flow.src_ip,
                                     ipv4_dst=flow.dst_ip,
@@ -121,8 +116,8 @@ class QosControl(app_manager.RyuApp):
                                                table_id=self.table_id,
                                                priority=self.app_limit_priority,
                                                match=match,
-                                               meter_id=meter_id,
-                                               idle_timeout=10)
+                                               meter_id=int(new_meter_id),
+                                               idle_timeout=100)
         self.bandwidth_update_handler()
 
 
@@ -133,14 +128,13 @@ class QosControl(app_manager.RyuApp):
             return
         for mac,meter in app_setting.iteritems():
             target_host = forwarding_config.member_list.get(mac)
-            if (target_host.mac == flow.dst_mac) or (target_host.ip == flow.dst_ip) or (mac == 'all'):
+            if (mac == 'all') or (target_host.mac == flow.dst_mac) or (target_host.ip == flow.dst_ip):
                 meter_id = meter.get('meter_id')
                 bandwidth = meter.get('bandwidth')
                 datapath = self.MyDATAPATH
                 parser = datapath.ofproto_parser
                 if flow.ip_proto == inet.IPPROTO_TCP:
-                     match = parser.OFPMatch(eth_src=flow.src_mac,
-                                    eth_dst=flow.dst_mac,
+                     match = parser.OFPMatch(
                                     eth_type=ether.ETH_TYPE_IP,
                                     ipv4_src=flow.src_ip,
                                     ipv4_dst=flow.dst_ip,
@@ -148,8 +142,7 @@ class QosControl(app_manager.RyuApp):
                                     tcp_src=flow.src_port,
                                     tcp_dst=flow.dst_port)
                 else:
-                     match = parser.OFPMatch(eth_src=flow.src_mac,
-                                    eth_dst=flow.dst_mac,
+                     match = parser.OFPMatch(
                                     eth_type=ether.ETH_TYPE_IP,
                                     ipv4_src=flow.src_ip,
                                     ipv4_dst=flow.dst_ip,
@@ -175,18 +168,17 @@ class QosControl(app_manager.RyuApp):
                 flow_limited = []
                 if mac == "all" :
                     for key,flow in forwarding_config.flow_list.iteritems():
-                        if flow.dst_ip.startswith("192.168") and flow.app == app:
+                        if flow.dst_ip.startswith("192.168") and flow.app == app and flow.rate > 0:
                             flow_limited.append(flow)
                 else:
                     for key,flow in forwarding_config.flow_list.iteritems():
                         target_host = forwarding_config.member_list.get(mac)
-                        if flow.dst_ip == target_host.ip and flow.app == app:
+                        if flow.dst_ip == target_host.ip and flow.app == app and flow.rate > 0:
                             flow_limited.append(flow)
-
                 if len(flow_limited) == 0 :
                     continue
-                elif qos_config.meter.get(meter_id) != str(bandwidth/len(flow_limited)) :
-                    ofp_helper.mod_meter(datapath, bandwidth/len(flow_limited), meter_id)
+                elif qos_config.meter.get(meter_id) != str(int(bandwidth)/len(flow_limited)) :
+                    ofp_helper.mod_meter(datapath, int(bandwidth)/len(flow_limited), meter_id)
                     self._request_meter_config_stats(datapath)
 
     @set_ev_cls(App_UpdateEvent)
@@ -203,7 +195,6 @@ class QosControl(app_manager.RyuApp):
                          + str(flow_info.ip_proto))
                 url = qos_config.get_flowstatistic_info + m.hexdigest()
                 response = requests.get(url)
-                flow_info.counter = flow_info.counter + 1
                 if response.status_code == 200:
                     json_data = response.json()
                 else:
@@ -221,6 +212,7 @@ class QosControl(app_manager.RyuApp):
                 if json_data is not None:
                     app_name = json_data.get('classifiedResult').get('classifiedName')
                     flow_info.app = app_name
+                    flow_info.limited = 4
                     #Let this flow adding the rate limitation meter
                     self.flow_meter_add_handler(flow_info)
         self.bandwidth_update_handler()
@@ -367,7 +359,7 @@ class QosControlController(ControllerBase):
         mac = str(kwargs['mac'])
         json_data = json.loads(req.body)
         bandwidth = str(json_data.get('bandwidth'))
-        qos_control.rate_limit_for_member(mac,bandwidth)
+        qos_control.rate_limit_for_member(mac, bandwidth)
         return Response(status=202)
 
     @route('set_ratelimit_for_app', urls.put_qos_rate_limit_app, methods=['PUT'])
@@ -376,9 +368,9 @@ class QosControlController(ControllerBase):
 
         app = str(kwargs['app'])
         json_data = json.loads(req.body)
-        bandwidth = int(json_data.get('bandwidth'))
+        bandwidth = str(json_data.get('bandwidth'))
         mac = str(json_data.get('mac'))
-        qos_control.rate_limit_for_app(app,mac,bandwidth)
+        qos_control.rate_limit_for_app(app, mac, bandwidth)
         return Response(status=202)
 
     @route('get_rate_for_host', urls.get_host_rate, methods=['GET'])
@@ -399,11 +391,14 @@ class QosControlController(ControllerBase):
     def get_rate_in_app(self, req, **kwargs):
         applist = {}
         for key, value in forwarding_config.flow_list.iteritems():
-            if applist.get(value.app) is None and value.rate != 0:
+            if applist.get(value.app) is None and value.rate != 0 and value.limited == 0:
                 applist[value.app] = {'all': value.rate*8, value.dst_ip: value.rate*8}
-            elif value.dst_ip is not None and value.rate != 0:
+            elif value.dst_ip is not None and value.rate != 0  and value.limited == 0:
                 dic = applist.get(value.app)
-                dic[value.dst_ip] = value.rate*8
+                if dic.get(value.dst_ip) is None:
+                    dic[value.dst_ip] = value.rate*8
+                else:
+                    dic[value.dst_ip] += value.rate*8
                 dic['all'] += value.rate*8
         body = json.dumps(applist)
         return Response(content_type='application/json', body=body)


### PR DESCRIPTION
1. Avoid the high rate peak with limitation when the new flow after classification , the rate will be counted after few second. Because the flow need time to set the meter when the new flow is be classification. 
2. Remove the src_mac and dst_mac in match field. Because it doesn't in the forwarding table , it will be none.

